### PR TITLE
Updated HOW TO RUN section of readme so others can run locally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "GeoRondo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
HOW TO RUN instructions were out of date and assumed the user already had the proper installations. New instructions should enable anyone to download and locally run GeoRondo.